### PR TITLE
Only take trusted scroll events into account

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -185,7 +185,7 @@ Modifications to the DOM specification {#sec-modifications-DOM}
 
     Right after step 1, we add the following step:
 
-    * If |target|'s [=relevant global object=] is a {{Window}} object and if <var ignore>event</var>'s {{Event/type}} is {{scroll}}, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
+    * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{scroll}} and its {{Event/isTrusted}} is false, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
 </div>
 
 Modifications to the HTML specification {#sec-modifications-HTML}


### PR DESCRIPTION
Fixes #30 

@npm1 - can you take a look? This also requires a test (to make sure these events don't stop LCP from reporting large paint that happen after them)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/pull/33.html" title="Last updated on Jul 25, 2019, 1:36 PM UTC (eeeb4a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/33/9681547...eeeb4a7.html" title="Last updated on Jul 25, 2019, 1:36 PM UTC (eeeb4a7)">Diff</a>