### PR TITLE
Set startTime to the either renderTime or loadTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -116,7 +116,7 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the value it was initialized to.
 
-The {{PerformanceEntry/startTime}} attribute's getter must return 0.
+The {{PerformanceEntry/startTime}} attribute's getter must return the value of the <a>context object</a>'s <a>renderTime</a> if it is not 0, and the value of the <a>context object</a>'s <a>loadTime</a> otherwise.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
 


### PR DESCRIPTION
Because entries are sorted whenever getEntries* is called, a startTime of zero will misorder the results. Setting the startTime to the renderTime, and to the loadTime if the latter is not available makes more sense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/pull/34.html" title="Last updated on Jul 25, 2019, 9:50 PM UTC (c68ac35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/34/510849f...c68ac35.html" title="Last updated on Jul 25, 2019, 9:50 PM UTC (c68ac35)">Diff</a>