### PR TITLE
Change status to CG DRAFT

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,6 @@
 <pre class=metadata>
 Title: Largest Contentful Paint
-Status: ED
+Status: CG-DRAFT
 Shortname: largest-contentful-paint
 Group: WICG
 Level: 1


### PR DESCRIPTION
Apparently ED is for W3C. Fixes https://github.com/WICG/largest-contentful-paint/issues/45


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/pull/46.html" title="Last updated on Nov 18, 2019, 6:17 PM UTC (899854e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/46/b200288...899854e.html" title="Last updated on Nov 18, 2019, 6:17 PM UTC (899854e)">Diff</a>