### PR TITLE
Allow removed content

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -75,7 +75,7 @@ The Largest Contentful Paint API will only expose element types that are already
 Largest content {#sec-largest-content}
 ------------------------
 
-The algorithm used for this API keeps track of the content seen so far. Whenever a new largest content is found, a new entry is created for it. Content that is removed is still considered by the algorithm. In particular, if the content removed was the largest, then a new entry is created only if something larger is ever added. The algorithm terminates whenever scroll or input events occur, since those are likely to introduce new content into the website.
+The algorithm used for this API keeps track of the content seen so far. Whenever a new largest content is found, a new entry is created for it. Content that is removed is still considered by the algorithm. In particular, if the content removed was the largest, then a new entry is created only if larger content is ever added. The algorithm terminates whenever scroll or input events occur, since those are likely to introduce new content into the website.
 
 Usage example {#sec-example}
 ------------------------
@@ -159,7 +159,7 @@ Note: The above algorithm defines that an element that is no longer <a>descendan
 This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
 It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with <a>pairs</a> with an {{Element}} as the first item and a {{Request}} as the second item. This is used for performance, to enable the algorithm to only consider each content once.
 
-Note: The user agent needs to ensure to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>pairs</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
+Note: The user agent needs to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>pairs</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
 
 Processing model {#sec-processing-model}
 ========================================

--- a/index.bs
+++ b/index.bs
@@ -36,7 +36,6 @@ urlPrefix: https://dom.spec.whatwg.org; spec: DOM;
     type: attribute; for: Element;
         text: element id; url: #dom-element-id;
     type: dfn; url: #concept-event-dispatch; text: event dispatch algorithm;
-    type: dfn; url: #concept-node-remove; text: node removal algorithm;
 urlPrefix: https://wicg.github.io/event-timing; spec: EVENT-TIMING;
     type: dfn; url: #has-dispatched-input-event; text: has dispatched input event;
 urlPrefix: https://fetch.spec.whatwg.org/; spec: FETCH;
@@ -76,7 +75,7 @@ The Largest Contentful Paint API will only expose element types that are already
 Largest content {#sec-largest-content}
 ------------------------
 
-The algorithm used for this API keeps track of the content seen so far. Whenever a new largest content is found, a new entry is created for it. Whenever content is removed, that content is no longer considered by the algorithm. In particular, if the content removed was the largest, then a new entry is created for the new largest. The algorithm terminates whenever scroll or input events occur, since those are likely to introduce new content into the website.
+The algorithm used for this API keeps track of the content seen so far. Whenever a new largest content is found, a new entry is created for it. Content that is removed is still considered by the algorithm. In particular, if the content removed was the largest, then a new entry is created only if something larger is ever added. The algorithm terminates whenever scroll or input events occur, since those are likely to introduce new content into the website.
 
 Usage example {#sec-example}
 ------------------------
@@ -104,7 +103,7 @@ The LargestContentfulPaint API is based on heuristics. As such, it is error pron
 
 * The algorithm halts when it detects certain types of user inputs. However, this means that the algorithm will not capture the main content if the user input occurs before the main content is displayed. In fact, the algorithm may produce meaningless results or no results at all if user input occurs very early.
 
-* To account for splash screens, content cannot be considered as the largest once it is removed. This presents problems for websites with large image carousels where images rotate automatically. If the image is removed when the next one is painted and the carousel is the largest content, the algorithm will continuously update based on carousel updates.
+* To account for image carousels, content is still considered as the largest even if it's removed. This presents problems for websites with splash screens that use large content as placeholders.
 
 Largest Contentful Paint {#sec-largest-contentful-paint}
 =======================================
@@ -157,12 +156,10 @@ The {{LargestContentfulPaint/element}} attribute's getter must return the value 
 
 Note: The above algorithm defines that an element that is no longer <a>descendant</a> of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
 
-This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0, and a <dfn>largest content</dfn>, initially set to null.
-It also adds an associated <dfn>content map</dfn>, which is initially an empty <a>map</a>. The [=content map=] will be filled with entries with the following format:
-* The key will be a <a>pair</a> with an {{Element}} as the first item and a {{Request}} as the second item. This allows identifying the content. The second item will be null for text content.
-* The value will be a map which contains information that is required to fill up the {{LargestContentfulPaint}} entry. This allows exposing a new {{LargestContentfulPaint}} entry when content is removed from the page.
+This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
+It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with <a>pairs</a> with an {{Element}} as the first item and a {{Request}} as the second item. This is used for performance, to enable the algorithm to only consider each content once.
 
-Note: A user agent probably wants to implement the {{Document}}'s associated concepts using a priority queue or binary search tree to avoid the O(n) cost of finding the largest size within <a>content map</a> when <a>largest content</a> is removed.
+Note: The user agent needs to ensure to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>pairs</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
 
 Processing model {#sec-processing-model}
 ========================================
@@ -185,7 +182,8 @@ In order to <dfn export>potentially add a {{LargestContentfulPaint}} entry</dfn>
     : Output
     ::  None
         1. Let |contentIdentifier| be the <a>pair</a> (|element|, |imageRequest|).
-        1. If |document|'s [=content map=] <a data-link-for=map>contains</a> |contentIdentifier|, return.
+        1. If |document|'s [=content set=] <a for=set>contains</a> |contentIdentifier|, return.
+        1. <a for=set>Append</a> |contentIdentifier| to |document|'s [=content set=]
         1. Let |window| be |document|’s [=relevant global object=].
         1. If either of |window|'s [=has dispatched scroll event=] or [=has dispatched input event=] is true, return.
         1. Let |url| be the empty string.
@@ -201,29 +199,9 @@ In order to <dfn export>potentially add a {{LargestContentfulPaint}} entry</dfn>
             1. Let |displaySize| be <code>|displayWidth| * |displayHeight|</code>.
             1. Let |penaltyFactor| be <code>min(|displaySize|, |naturalSize|) / |displaySize|</code>.
             1. Multiply |size| by |penaltyFactor|.
-        1. Let |contentInfo| be a map with |contentInfo|["size"] = |size|, |contentInfo|["url"] = |url|, |contentInfo|["id"] = |id|, |contentInfo|["renderTime"] = |renderTime|, and |contentInfo|["loadTime"] = |loadTime|.
-        1. Add a new entry with |contentIdentifier| as the key and |contentInfo| as the value to |document|'s [=content map=].
-        1. If |size| is smaller or equal to |document|'s [=largest contentful paint size=], return.
-        1. <a>Create a LargestContentfulPaint entry</a> with |element|, |contentInfo|, and |document| as inputs.
-</div>
-
-Remove element content {#sec-remove-element-content}
---------------------------------------------------------
-
-In order to <dfn>remove element content</dfn>, the user agent must run the following steps:
-<div algorithm="LargestContentfulPaint remove-element">
-    : Input
-    ::  |element|, an <a>Element</a>
-    ::  |document|, a <a>Document</a>
-    : Output
-    ::  None
-        1. For each |entry| of |document|'s [=content map=]:
-            1. If |entry|'s key is a <a>pair</a> whose first item is equal to |element|, <a for=map>remove</a> |entry| from |document|'s [=content map=].
-        1. If |document|'s [=largest content=] is a <a>pair</a> whose first item is not equal to |element|, then return.
-        1. Let |largestSize| be 0, let |largestContentIdentifier| be null, and let |largestContentInfo| be null.
-        1. For each |key| → |value| of |document|'s [=content map=]:
-            1. If |value|["size"] is greater than |largestSize|, set |largestSize| to |value|["size"], |largestContentIdentifier| to |key|, and |largestContentInfo| to |value|.
-        1. If |largestContentIdentifier| is not null, <a>create a LargestContentfulPaint entry</a> with |largestContentIdentifier|, |largestContentInfo|, and |document| as inputs.
+        1. If |size| is less than or equal to |document|'s [=largest contentful paint size=], return.
+        1. Let |contentInfo| be a <a>map</a> with |contentInfo|["size"] = |size|, |contentInfo|["url"] = |url|, |contentInfo|["id"] = |id|, |contentInfo|["renderTime"] = |renderTime|, |contentInfo|["loadTime"] = |loadTime|, and contentInfo["element"] = |element|.
+        1. <a>Create a LargestContentfulPaint entry</a> with |contentInfo|, and |document| as inputs.
 </div>
 
 Create a LargestContentfulPaint entry {#sec-create-entry}
@@ -233,12 +211,10 @@ In order to <dfn>create a {{LargestContentfulPaint}} entry</dfn>, the user agent
 
 <div algorithm="LargestContentfulPaint create-entry">
     : Input
-    ::  |contentIdentifier|, a <a>pair</a>
     ::  |contentInfo|, a <a>map</a>
     ::  |document|, a {{Document}}
     : Output
     ::  None
-        1. Set |document|'s [=largest content=] to |contentIdentifier|.
         1. Set |document|'s [=largest contentful paint size=] to |contentInfo|["size"].
         1. Let |entry| be a new {{LargestContentfulPaint}} entry with |document|'s [=relevant realm=], with its
             * {{LargestContentfulPaint/size}} set to |contentInfo|["size"],
@@ -246,7 +222,7 @@ In order to <dfn>create a {{LargestContentfulPaint}} entry</dfn>, the user agent
             * {{LargestContentfulPaint/id}} set to |contentInfo|["id"],
             * {{LargestContentfulPaint/renderTime}} set to |contentInfo|["renderTime"],
             * {{LargestContentfulPaint/loadTime}} set to |contentInfo|["loadTime"],
-            * and {{LargestContentfulPaint/element}} set to |contentIdentifier|'s first item.
+            * and {{LargestContentfulPaint/element}} set to |contentInfo|["element"].
         1. [=Queue the PerformanceEntry=] |entry|.
 </div>
 
@@ -262,14 +238,6 @@ Modifications to the DOM specification {#sec-modifications-DOM}
 
     * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{scroll}} and its {{Event/isTrusted}} is false, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
 </div>
-
-<div algorithm="addition to element removal">
-    Add the following step at the end of the <a>node removal algorithm</a>:
-
-    * Call the algorithm to <a>remove element content</a> passing in |node| and |node|'s <a>node document</a>.
-</div>
-
-Issue(41): background image changes or changes in image <code>src</code> should trigger removal from the {{Document}}'s <a>content map</a>.
 
 Modifications to the HTML specification {#sec-modifications-HTML}
 ----------------------------------------


### PR DESCRIPTION
Fixes https://github.com/WICG/largest-contentful-paint/issues/41

We simplify the processing model:
* The user agent can keep a set instead of a map, and we do not need to specify the memory management because it is not web exposed (it serves the purpose of performance optimization of the algorithm.
* We no longer need an algorithm on element removal.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/pull/65.html" title="Last updated on Nov 6, 2020, 4:15 PM UTC (d572882)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/largest-contentful-paint/65/0060878...d572882.html" title="Last updated on Nov 6, 2020, 4:15 PM UTC (d572882)">Diff</a>