### PR TITLE
Remove context object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -138,19 +138,19 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the empty string.
 
-The {{PerformanceEntry/startTime}} attribute's getter must return the value of the <a>context object</a>'s <a>renderTime</a> if it is not 0, and the value of the <a>context object</a>'s <a>loadTime</a> otherwise.
+The {{PerformanceEntry/startTime}} attribute's getter must return the value of <a>this</a>'s <a>renderTime</a> if it is not 0, and the value of <a>this</a>'s <a>loadTime</a> otherwise.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-The {{LargestContentfulPaint/renderTime}} attribute must return the value of the <a>context object</a>'s <a>renderTime</a>.
+The {{LargestContentfulPaint/renderTime}} attribute must return the value of <a>this</a>'s <a>renderTime</a>.
 
-The {{LargestContentfulPaint/loadTime}} attribute must return the value of the <a>context object</a>'s <a>loadTime</a>.
+The {{LargestContentfulPaint/loadTime}} attribute must return the value of <a>this</a>'s <a>loadTime</a>.
 
-The {{LargestContentfulPaint/size}} attribute must return the value of the <a>context object</a>'s <a>size</a>.
+The {{LargestContentfulPaint/size}} attribute must return the value of <a>this</a>'s <a>size</a>.
 
-The {{LargestContentfulPaint/id}} attribute must return the value of the <a>context object</a>'s <a>id</a>.
+The {{LargestContentfulPaint/id}} attribute must return the value of <a>this</a>'s <a>id</a>.
 
-The {{LargestContentfulPaint/url}} attribute must return the value of the <a>context object</a>'s <a>url</a>.
+The {{LargestContentfulPaint/url}} attribute must return the value of <a>this</a>'s <a>url</a>.
 
 The {{LargestContentfulPaint/element}} attribute's getter must return the value returned by running the <a>get an element</a> algorithm with <a>element</a> and null as inputs.
 


### PR DESCRIPTION
Replaces `context object` with `this`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2021, 9:21 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Flargest-contentful-paint%2F86c0c4c0975b640d33a4913fce395b63aae4fc20%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't load MDN Spec Links data for this spec.
Expecting value: line 1 column 1 (char 0)
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/largest-contentful-paint%2375.)._
</details>
